### PR TITLE
[ch18288] Order number filter in Downloads reports not working

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ $order_number = $order->get_order_number();
 
 == Changelog ==
 
+= 2019.nn.nn - version 1.9.1-dev.1 =
+ * Fix - Fix order number filter in WooCommerce Admin Downloads Analytics
+
 = 2019.08.15 - version 1.9.0 =
 * Misc - Add support for WooCommerce 3.7
 * Misc - Remove support for WooCommerce 2.6

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.0
+ * Version: 1.9.1-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.0';
+	const VERSION = '1.9.1-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.0.9';

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -110,7 +110,8 @@ class WC_Seq_Order_Number {
 		add_filter( 'wcs_renewal_order_created',    array( $this, 'subscriptions_set_sequential_order_number' ), 10, 2 );
 
 		// WooCommerce Admin support
-		if ( class_exists( 'WC_Admin_Install', false ) ) {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Install', false ) ||
+		     class_exists( 'WC_Admin_Install', false ) ) {
 			add_filter( 'woocommerce_rest_orders_prepare_object_query', array( $this, 'wc_admin_order_number_api_param' ), 10, 2 );
 		}
 


### PR DESCRIPTION
# Summary

This release fixes the order number filter in WC Admin Downloads report for WC Admin >= 0.19.0

### Stories

- [CH 18284](https://app.clubhouse.io/skyverge/story/18284/order-number-filter-in-downloads-reports-not-working)

## Details

The class we are using to detect WC Admin was renamed in WC Admin 0.19.0.

## QA

These steps were copied from https://github.com/skyverge/wc-plugins/pull/3116

### Setup

- Install WooCommerce admin
- Have several orders in your admin that include downloadables

### Cases

1. Search orders in ordinary Orders view in WooCommerce > Orders: you should be able to search orders by order number set by Sequential Order Numbers Pro as usual.
1. Head over Analytics > Downloads and set an advanced filter ("show" > "advanced filters") to search by order numbers
1. In the search field type the order number (not order ID) of an order set with SONP (note: ignore prefix/suffix here, as you can't search by those).

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version