### PR TITLE
[ch18875] WC 3.8 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 4.4
 Tested up to: 5.2.3
-Stable tag: 1.9.1
+Stable tag: 1.9.2-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 
@@ -100,6 +100,9 @@ $order_number = $order->get_order_number();
 `
 
 == Changelog ==
+
+= 2019.nn.nn - version 1.9.2-dev.1 =
+ * Misc - Add support for WooCommerce 3.8
 
 = 2019.10.03 - version 1.9.1 =
  * Fix - Fix order number filter in WooCommerce Admin Downloads Analytics

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.1
+ * Version: 1.9.2-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -19,7 +19,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9
- * WC tested up to: 3.7.0
+ * WC tested up to: 3.8.0
  */
 
 defined( 'ABSPATH' ) or exit;
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.1';
+	const VERSION = '1.9.2-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This release adds support for WC 3.8.

### Stories

- [CH 18875](https://app.clubhouse.io/skyverge/story/18875)

## Details

Sequential Order Numbers doesn't use the framework, so this is just a version bump & wc-tested-to bump.

## QA

- Activate WC Admin
- Activate Sequential Order Numbers
- Place a few orders
- [x] Order numbers are sequential

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version