### PR TITLE
WC 3.9 Compatibility Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ $order_number = $order->get_order_number();
 
 == Changelog ==
 
+= 2020.nn.nn - version 1.9.3-dev.1 =
+ * Misc - Add support for WooCommerce 3.9
+
 = 2019.11.05 - version 1.9.2 =
  * Misc - Add support for WooCommerce 3.8
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 4.4
 Tested up to: 5.2.4
-Stable tag: 1.9.2
+Stable tag: 1.9.3-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -9,13 +9,13 @@
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2012-2019, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2012-2019, SkyVerge, Inc.
+ * @copyright Copyright (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.2
+ * Version: 1.9.3-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.2';
+	const VERSION = '1.9.3-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 3.9 and updates the copyright year to 2020.

### Stories

- [CH 24728](https://app.clubhouse.io/skyverge/story/24728/woocommerce-3-9-compatibility)

## Details

There were no incompatibilities with WC 3.9.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
