### PR TITLE
WooCommerce 4.0 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -102,6 +102,7 @@ $order_number = $order->get_order_number();
 == Changelog ==
 
 = 2020.nn.nn - version 1.9.4-dev.1 =
+ * Misc - Add support for WooCommerce 4.0
 
 = 2020.02.05 - version 1.9.3 =
  * Misc - Add support for WooCommerce 3.9

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 4.4
 Tested up to: 5.3.2
-Stable tag: 1.9.3
+Stable tag: 1.9.4-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 
@@ -100,6 +100,8 @@ $order_number = $order->get_order_number();
 `
 
 == Changelog ==
+
+= 2020.nn.nn - version 1.9.4-dev.1 =
 
 = 2020.02.05 - version 1.9.3 =
  * Misc - Add support for WooCommerce 3.9

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.3
+ * Version: 1.9.4-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.3';
+	const VERSION = '1.9.4-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.0.9';


### PR DESCRIPTION
# Summary

This PR adds support for WooCommerce 4.0.

### Stories

- [CH 31039](https://app.clubhouse.io/skyverge/story/31039/woocommerce-4-0-compatibility)

## Details

There were no incompatibilities with WC 4.0.

## QA

- [x] Generate new orders and check for sequential numbers

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version