### PR TITLE
Bumps version number to 1.9.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ This plugin extends WooCommerce by setting sequential order numbers for new orde
 
 This plugin extends WooCommerce by automatically setting sequential order numbers for new orders.  If there are existing orders at the time of installation, the sequential order numbers will start with the highest current order number.
 
-**This plugin requires WooCommerce 3.0.9 or newer.**
+**This plugin requires WooCommerce 3.9.4 or newer.**
 
 > No configuration needed! The plugin is so easy to use, there aren't even any settings. Activate it, and orders will automatically become sequential.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 4.4
 Tested up to: 5.4.1
-Stable tag: 1.9.5
+Stable tag: 1.9.6
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 
@@ -100,6 +100,9 @@ $order_number = $order->get_order_number();
 `
 
 == Changelog ==
+
+= 2022.02.25 - version 1.9.6 =
+ * Misc - Tests Compatibility with WordPress 5.9.1
 
 = 2020.05.07 - version 1.9.5 =
  * Misc - Add support for WooCommerce 4.1

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ $order_number = $order->get_order_number();
 
 = 2022.nn.nn - version 1.9.6-dev.1 =
  * Misc - Require WooCommerce 3.9.4 or newer
+ * Misc - Replace calls to deprecated `is_ajax()` with `wp_doing_ajax()`
 
 = 2020.05.07 - version 1.9.5 =
  * Misc - Add support for WooCommerce 4.1

--- a/readme.txt
+++ b/readme.txt
@@ -101,8 +101,8 @@ $order_number = $order->get_order_number();
 
 == Changelog ==
 
-= 2022.02.25 - version 1.9.6 =
- * Misc - Tests Compatibility with WordPress 5.9.1
+= 2022.nn.nn - version 1.9.6-dev.1 =
+ * Misc - Require WooCommerce 3.9.4 or newer
 
 = 2020.05.07 - version 1.9.5 =
  * Misc - Add support for WooCommerce 4.1

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
 Requires at least: 4.4
 Tested up to: 5.4.1
-Stable tag: 1.9.6
+Stable tag: 1.9.6-dev.1
 
 This plugin extends WooCommerce by setting sequential order numbers for new orders.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Sequential Order Numbers ===
 Contributors: SkyVerge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, order number, sequential order number, woocommerce orders
-Requires at least: 4.4
+Requires at least: 4.7
 Tested up to: 5.4.1
 Stable tag: 1.9.6-dev.1
 

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -125,7 +125,7 @@ class WC_Seq_Order_Number {
 		}
 
 		// Installation
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			$this->install();
 		}
 	}
@@ -463,7 +463,7 @@ class WC_Seq_Order_Number {
 		// if a plugin defines a minimum WC version, render a notice and skip loading the plugin
 		if ( defined( 'self::MINIMUM_WC_VERSION' ) && version_compare( self::get_wc_version(), self::MINIMUM_WC_VERSION, '<' ) ) {
 
-			if ( is_admin() && ! is_ajax() && ! has_action( 'admin_notices', array( $this, 'render_update_notices' ) ) ) {
+			if ( is_admin() && ! wp_doing_ajax() && ! has_action( 'admin_notices', array( $this, 'render_update_notices' ) ) ) {
 
 				add_action( 'admin_notices', array( $this, 'render_update_notices' ) );
 			}

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.6
+ * Version: 1.9.6-dev.1
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.6';
+	const VERSION = '1.9.6-dev.1';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.0.9';

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -18,7 +18,7 @@
  * @copyright Copyright (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
- * WC requires at least: 3.0.9
+ * WC requires at least: 3.9.4
  * WC tested up to: 4.1.0
  */
 
@@ -36,7 +36,7 @@ class WC_Seq_Order_Number {
 	const VERSION = '1.9.6-dev.1';
 
 	/** minimum required wc version */
-	const MINIMUM_WC_VERSION = '3.0.9';
+	const MINIMUM_WC_VERSION = '3.9.4';
 
 	/** @var \WC_Seq_Order_Number single instance of this plugin */
 	protected static $instance;

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -5,7 +5,7 @@
  * Description: Provides sequential order numbers for WooCommerce orders
  * Author: SkyVerge
  * Author URI: http://www.skyverge.com
- * Version: 1.9.5
+ * Version: 1.9.6
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
@@ -33,7 +33,7 @@ class WC_Seq_Order_Number {
 
 
 	/** version number */
-	const VERSION = '1.9.5';
+	const VERSION = '1.9.6';
 
 	/** minimum required wc version */
 	const MINIMUM_WC_VERSION = '3.0.9';

--- a/woocommerce-sequential-order-numbers.php
+++ b/woocommerce-sequential-order-numbers.php
@@ -9,13 +9,13 @@
  * Text Domain: woocommerce-sequential-order-numbers
  * Domain Path: /i18n/languages/
  *
- * Copyright: (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
+ * Copyright: (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
  *
  * License: GNU General Public License v3.0
  * License URI: http://www.gnu.org/licenses/gpl-3.0.html
  *
  * @author    SkyVerge
- * @copyright Copyright (c) 2012-2020, SkyVerge, Inc. (info@skyverge.com)
+ * @copyright Copyright (c) 2012-2022, SkyVerge, Inc. (info@skyverge.com)
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.0.9


### PR DESCRIPTION
# Summary <!-- Required -->
Tests and bumps version number to 1.9.6 and compatible with WordPress 5.9.1

### Issue: [MWC-4386](https://jira.godaddy.com/browse/MWC-4386)

## QA <!-- Optional -->
- [ ] Would like to confirm that this is all that's needed for WordPress plugin repo?

## Before merge <!-- Required -->

- [x] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [x] This PR makes the appropriate modifications to documentation or explains why none are needed
- [x] This change does not impact usage or expected outputs of covered code